### PR TITLE
Endpoint protocols renaming.

### DIFF
--- a/Sources/APIota/APIotaClient.swift
+++ b/Sources/APIota/APIotaClient.swift
@@ -8,20 +8,20 @@ public protocol APIotaClient {
     
     var baseUrlComponents: URLComponents { get }
     
-    func sendRequest<T: APIotaEndpoint>(for endpoint: T,
-                                        callback: @escaping (Result<T.Response, Error>) -> Void)
+    func sendRequest<T: APIotaCodableEndpoint>(for endpoint: T,
+                                               callback: @escaping (Result<T.Response, Error>) -> Void)
 
     @available(iOS 13.0, macOS 10.15, *)
-    func sendRequest<T: APIotaEndpoint>(for endpoint: T) -> AnyPublisher<T.Response, Error>
+    func sendRequest<T: APIotaCodableEndpoint>(for endpoint: T) -> AnyPublisher<T.Response, Error>
 }
 
 // MARK: - Default method implementations
 
 public extension APIotaClient {
     
-    func sendRequest<T: APIotaEndpoint>(for endpoint: T,
-                                        callback: @escaping (Result<T.Response, Error>) -> Void) {
-        
+    func sendRequest<T: APIotaCodableEndpoint>(for endpoint: T,
+                                               callback: @escaping (Result<T.Response, Error>) -> Void) {
+
         var request: URLRequest!
         do {
             request = try endpoint.request(baseUrlComponents: baseUrlComponents)
@@ -54,7 +54,7 @@ public extension APIotaClient {
     }
 
     @available(iOS 13.0, macOS 10.15, *)
-    func sendRequest<T: APIotaEndpoint>(for endpoint: T) -> AnyPublisher<T.Response, Error> {
+    func sendRequest<T: APIotaCodableEndpoint>(for endpoint: T) -> AnyPublisher<T.Response, Error> {
 
         var request: URLRequest!
         do {

--- a/Sources/APIota/APIotaCodableEndpoint.swift
+++ b/Sources/APIota/APIotaCodableEndpoint.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol APIotaEndpoint {
+public protocol APIotaCodableEndpoint {
     associatedtype Response: Decodable
     associatedtype Body: Encodable
     
@@ -19,7 +19,7 @@ public protocol APIotaEndpoint {
 
 // MARK: - Default method implementations
 
-extension APIotaEndpoint {
+extension APIotaCodableEndpoint {
     
     func request(baseUrlComponents: URLComponents) throws -> URLRequest {
         

--- a/Sources/APIota/APIotaURLEncodedFormEndpoint.swift
+++ b/Sources/APIota/APIotaURLEncodedFormEndpoint.swift
@@ -1,14 +1,17 @@
 import Foundation
 
-public protocol APIotaURLEncodedEndpoint: APIotaEndpoint {
+public protocol APIotaURLEncodedFormEndpoint: APIotaCodableEndpoint where Body == Data {
 
     var requestBodyQueryItems: [URLQueryItem] { get }
 }
 
-extension APIotaURLEncodedEndpoint {
+extension APIotaURLEncodedFormEndpoint {
 
     var httpBody: Body? {
-        nil
+        var requestBodyComponents = URLComponents()
+        requestBodyComponents.queryItems = requestBodyQueryItems
+
+        return requestBodyComponents.query?.data(using: .utf8)
     }
 
     var httpMethod: HTTPMethod {
@@ -27,10 +30,7 @@ extension APIotaURLEncodedEndpoint {
 
         var request = URLRequest(url: requestUrl)
         request.httpMethod = httpMethod.rawValue
-
-        var requestBodyComponents = URLComponents()
-        requestBodyComponents.queryItems = requestBodyQueryItems
-        request.httpBody = requestBodyComponents.query?.data(using: .utf8)
+        request.httpBody = httpBody
 
         if let headers = headers {
             request.allHTTPHeaderFields = headers.allHTTPHeaderFields

--- a/Tests/APIotaTests/Network/TestAPIClient.swift
+++ b/Tests/APIotaTests/Network/TestAPIClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import APIota
 
-final class TestAPIClient: APIotaClient {
+struct TestAPIClient: APIotaClient {
 
     let session = URLSession.shared
 

--- a/Tests/APIotaTests/Network/TestAPIEndpoints.swift
+++ b/Tests/APIotaTests/Network/TestAPIEndpoints.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import APIota
 
-struct TestTodosGetEndpoint: APIotaEndpoint {
+struct TestTodosGetEndpoint: APIotaCodableEndpoint {
     typealias Response = [Todo]
     typealias Body = String
 
@@ -16,7 +16,7 @@ struct TestTodosGetEndpoint: APIotaEndpoint {
     let queryItems: [URLQueryItem]? = nil
 }
 
-struct TestTodosCreateEndpoint: APIotaEndpoint {
+struct TestTodosCreateEndpoint: APIotaCodableEndpoint {
     typealias Response = Todo
     typealias Body = Todo
 
@@ -31,7 +31,7 @@ struct TestTodosCreateEndpoint: APIotaEndpoint {
     let queryItems: [URLQueryItem]? = nil
 }
 
-struct TestTodosUpdateEndpoint: APIotaEndpoint {
+struct TestTodosUpdateEndpoint: APIotaCodableEndpoint {
     typealias Response = Todo
     typealias Body = Todo
 


### PR DESCRIPTION
This PR refactors some Protocol namings for clarity:

- Renames `APIotaEndpoint` -> `APIotaCodableEndpoint`.
- Renames `APIotaURLEncodedEndpoint ` -> `APIotaURLEncodedFormEndpoint `.