### PR TITLE
Correct access control errors for default method implementations

### DIFF
--- a/Sources/APIota/APIotaCodableEndpoint.swift
+++ b/Sources/APIota/APIotaCodableEndpoint.swift
@@ -33,7 +33,7 @@ public protocol APIotaCodableEndpoint {
 
 // MARK: - Default method implementations
 
-extension APIotaCodableEndpoint {
+public extension APIotaCodableEndpoint {
     
     func request(baseUrlComponents: URLComponents) throws -> URLRequest {
         

--- a/Sources/APIota/APIotaURLEncodedFormEndpoint.swift
+++ b/Sources/APIota/APIotaURLEncodedFormEndpoint.swift
@@ -10,7 +10,9 @@ public protocol APIotaURLEncodedFormEndpoint: APIotaCodableEndpoint where Body =
     var requestBodyQueryItems: [URLQueryItem] { get }
 }
 
-extension APIotaURLEncodedFormEndpoint {
+// MARK: - Default method implementations
+
+public extension APIotaURLEncodedFormEndpoint {
 
     /// A `Body` which is UTF-8 encoded `Data`, computed from `requestBodyQueryItems`.
     var httpBody: Body? {


### PR DESCRIPTION
This PR:

- Ensures that default method implementations for `APIotaCodableEndpoint` and `APIotaURLEncodedFormEndpoint` protocols are exposed as `public`.