### PR TITLE
Access control fixes

### DIFF
--- a/Sources/APIota/HTTP/HTTPHeader.swift
+++ b/Sources/APIota/HTTP/HTTPHeader.swift
@@ -8,7 +8,7 @@ public struct HTTPHeader {
 
     // MARK: Internal variables
 
-    internal let stringValue: String
+    let stringValue: String
 
     // MARK: - Initialization
 

--- a/Sources/APIota/HTTP/HTTPMediaType.swift
+++ b/Sources/APIota/HTTP/HTTPMediaType.swift
@@ -81,7 +81,7 @@ public struct HTTPMediaType {
 
 // MARK: - Default media type values
 
-extension HTTPMediaType {
+public extension HTTPMediaType {
 
     // UTF-8 charset
 


### PR DESCRIPTION
This PR resolves some issues relating to access control:

- Ensures all default `HTTPMediaType` static constants are made `public` (which makes sense since they are intended to be helper properties).
- Removes a redundant `internal` access control keyword (since members and methods default to `internal` even if the type they belong to is defined as `public`).