### PR TITLE
Platform support improvements

### DIFF
--- a/Example/APIotaExample/APIotaExample/ViewModel/TodosListViewModel.swift
+++ b/Example/APIotaExample/APIotaExample/ViewModel/TodosListViewModel.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if canImport(Combine)
 import Combine
+#endif
 import APIota
 
 class TodosListViewModel: ObservableObject {

--- a/Package.swift
+++ b/Package.swift
@@ -5,9 +5,6 @@ import PackageDescription
 
 let package = Package(
     name: "APIota",
-    platforms: [.iOS(.v13),
-                .macOS(.v10_15),
-                .tvOS(.v13)],
     products: [
         .library(
             name: "APIota",

--- a/README.md
+++ b/README.md
@@ -24,12 +24,6 @@ APIota is a lightweight Swift library for defining API clients for use in iOS an
 - Swift 5.1 or higher
 - Xcode 11.0 or higer
 
-### Minimum deployment targets
-
-- iOS 13.0
-- macOS 10.15
-- tvOS 13.0
-
 ## Features
 
 - [x] JSON request and response body encoding and decoding support when using `Codable` model objects.

--- a/Sources/APIota/APIotaClient.swift
+++ b/Sources/APIota/APIotaClient.swift
@@ -29,7 +29,7 @@ public protocol APIotaClient {
     /// Send a `URLRequest` to the specified REST API, returning a response via a Combine `AnyPublisher`.
     /// - Parameter endpoint: An `APIotaCodableEndpoint` defining the format of the `URLRequest` to be sent.
     /// - Returns: An `AnyPublisher` which can be integrated with SwiftUI or Combine code paths.
-    @available(iOS 13.0, macOS 10.15, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func sendRequest<T: APIotaCodableEndpoint>(for endpoint: T) -> AnyPublisher<T.Response, Error>
 }
 
@@ -71,7 +71,7 @@ public extension APIotaClient {
         dataTask.resume()
     }
 
-    @available(iOS 13.0, macOS 10.15, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func sendRequest<T: APIotaCodableEndpoint>(for endpoint: T) -> AnyPublisher<T.Response, Error> {
 
         var request: URLRequest!

--- a/Sources/APIota/APIotaClient.swift
+++ b/Sources/APIota/APIotaClient.swift
@@ -26,11 +26,15 @@ public protocol APIotaClient {
     func sendRequest<T: APIotaCodableEndpoint>(for endpoint: T,
                                                callback: @escaping (Result<T.Response, Error>) -> Void)
 
+    #if canImport(Combine)
+
     /// Send a `URLRequest` to the specified REST API, returning a response via a Combine `AnyPublisher`.
     /// - Parameter endpoint: An `APIotaCodableEndpoint` defining the format of the `URLRequest` to be sent.
     /// - Returns: An `AnyPublisher` which can be integrated with SwiftUI or Combine code paths.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func sendRequest<T: APIotaCodableEndpoint>(for endpoint: T) -> AnyPublisher<T.Response, Error>
+
+    #endif
 }
 
 // MARK: - Default method implementations
@@ -71,6 +75,8 @@ public extension APIotaClient {
         dataTask.resume()
     }
 
+    #if canImport(Combine)
+
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func sendRequest<T: APIotaCodableEndpoint>(for endpoint: T) -> AnyPublisher<T.Response, Error> {
 
@@ -98,4 +104,6 @@ public extension APIotaClient {
         .receive(on: DispatchQueue.main)
         .eraseToAnyPublisher()
     }
+
+    #endif
 }

--- a/Sources/APIota/APIotaClient.swift
+++ b/Sources/APIota/APIotaClient.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(Combine)
 import Combine
+#endif
 
 /// Defines an API Client.
 ///

--- a/Tests/APIotaTests/APIotaCRUDRequestsTests.swift
+++ b/Tests/APIotaTests/APIotaCRUDRequestsTests.swift
@@ -12,8 +12,12 @@ final class APIotaCRUDRequestsTests: XCTestCase {
 
     // MARK: - Private variables
 
+    #if canImport(Combine)
+
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     private(set) lazy var cancellable: AnyCancellable? = nil
+
+    #endif
 
     // MARK: - Test methods
 
@@ -40,6 +44,8 @@ final class APIotaCRUDRequestsTests: XCTestCase {
         wait(for: [expectation], timeout: 10.0)
     }
 
+    #if canImport(Combine)
+
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func testGETPublisher() {
 
@@ -63,6 +69,8 @@ final class APIotaCRUDRequestsTests: XCTestCase {
         wait(for: [expectation], timeout: 10.0)
     }
 
+    #endif
+
     func testDELETE() {
 
         let todoId = 98
@@ -85,6 +93,8 @@ final class APIotaCRUDRequestsTests: XCTestCase {
         wait(for: [expectation], timeout: 10.0)
     }
 
+    #if canImport(Combine)
+
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func testDELETEPublisher() {
 
@@ -105,6 +115,8 @@ final class APIotaCRUDRequestsTests: XCTestCase {
 
         wait(for: [expectation], timeout: 10.0)
     }
+
+    #endif
 
     func testPATCH() {
 
@@ -134,6 +146,8 @@ final class APIotaCRUDRequestsTests: XCTestCase {
         wait(for: [expectation], timeout: 10.0)
     }
 
+    #if canImport(Combine)
+
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func testPATCHPublisher() {
 
@@ -160,6 +174,8 @@ final class APIotaCRUDRequestsTests: XCTestCase {
 
         wait(for: [expectation], timeout: 10.0)
     }
+
+    #endif
 
     func testPOST() {
 
@@ -189,6 +205,8 @@ final class APIotaCRUDRequestsTests: XCTestCase {
         wait(for: [expectation], timeout: 10.0)
     }
 
+    #if canImport(Combine)
+
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func testPOSTPublisher() {
 
@@ -215,6 +233,8 @@ final class APIotaCRUDRequestsTests: XCTestCase {
 
         wait(for: [expectation], timeout: 10.0)
     }
+
+    #endif
 
     func testPUT() {
 
@@ -247,6 +267,8 @@ final class APIotaCRUDRequestsTests: XCTestCase {
         wait(for: [expectation], timeout: 10.0)
     }
 
+    #if canImport(Combine)
+
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func testPUTPublisher() {
 
@@ -277,6 +299,8 @@ final class APIotaCRUDRequestsTests: XCTestCase {
         wait(for: [expectation], timeout: 10.0)
     }
 
+    #endif
+
     // MARK: - Private methods
 
     private func verifyTodoList(_ todoList: [Todo],
@@ -303,6 +327,8 @@ final class APIotaCRUDRequestsTests: XCTestCase {
         XCTAssertEqual(todo.completed, expectedCompleted)
     }
 
+    #if canImport(Combine)
+
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     private func verifyPublisherCompletion(_ completion: Subscribers.Completion<Error>,
                                            expectation: XCTestExpectation) {
@@ -315,4 +341,6 @@ final class APIotaCRUDRequestsTests: XCTestCase {
 
         expectation.fulfill()
     }
+
+    #endif
 }

--- a/Tests/APIotaTests/APIotaCRUDRequestsTests.swift
+++ b/Tests/APIotaTests/APIotaCRUDRequestsTests.swift
@@ -1,5 +1,7 @@
 import XCTest
+#if canImport(Combine)
 import Combine
+#endif
 @testable import APIota
 
 final class APIotaCRUDRequestsTests: XCTestCase {

--- a/Tests/APIotaTests/APIotaCRUDRequestsTests.swift
+++ b/Tests/APIotaTests/APIotaCRUDRequestsTests.swift
@@ -12,7 +12,7 @@ final class APIotaCRUDRequestsTests: XCTestCase {
 
     // MARK: - Private variables
 
-    @available(iOS 13.0, macOS 10.15, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     private(set) lazy var cancellable: AnyCancellable? = nil
 
     // MARK: - Test methods
@@ -40,7 +40,7 @@ final class APIotaCRUDRequestsTests: XCTestCase {
         wait(for: [expectation], timeout: 10.0)
     }
 
-    @available(iOS 13.0, macOS 10.15, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func testGETPublisher() {
 
         let endpoint = TestTodosGetEndpoint()
@@ -85,7 +85,7 @@ final class APIotaCRUDRequestsTests: XCTestCase {
         wait(for: [expectation], timeout: 10.0)
     }
 
-    @available(iOS 13.0, macOS 10.15, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func testDELETEPublisher() {
 
         let todoId = 98
@@ -134,7 +134,7 @@ final class APIotaCRUDRequestsTests: XCTestCase {
         wait(for: [expectation], timeout: 10.0)
     }
 
-    @available(iOS 13.0, macOS 10.15, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func testPATCHPublisher() {
 
         let todoTitle = "PATCHed TODO"
@@ -189,7 +189,7 @@ final class APIotaCRUDRequestsTests: XCTestCase {
         wait(for: [expectation], timeout: 10.0)
     }
 
-    @available(iOS 13.0, macOS 10.15, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func testPOSTPublisher() {
 
         let todoTitle = "POSTed TODO"
@@ -247,7 +247,7 @@ final class APIotaCRUDRequestsTests: XCTestCase {
         wait(for: [expectation], timeout: 10.0)
     }
 
-    @available(iOS 13.0, macOS 10.15, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func testPUTPublisher() {
 
         let todoTitle = "PUTed TODO"
@@ -303,7 +303,7 @@ final class APIotaCRUDRequestsTests: XCTestCase {
         XCTAssertEqual(todo.completed, expectedCompleted)
     }
 
-    @available(iOS 13.0, macOS 10.15, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     private func verifyPublisherCompletion(_ completion: Subscribers.Completion<Error>,
                                            expectation: XCTestExpectation) {
         switch completion {


### PR DESCRIPTION
This PR:

- Ensures Combine-related functionality is not compiled on non-Apple platforms where it is unavailable (such as Linux).
- Expands `@available` checks for Combine functionality to cover tvOS 13.0 and watchOS 6.0 or above.
  - Removes the recently-added specific platform support from `Package.swift` and `README` as a result. (This was never present in a tagged release).