### PR TITLE
Error reporting improvements

### DIFF
--- a/Sources/APIota/APIotaClient.swift
+++ b/Sources/APIota/APIotaClient.swift
@@ -96,9 +96,11 @@ public extension APIotaClient {
 
             do {
                 callback(.success(try self.decoder.decode(T.SuccessResponse.self, from: data!)))
-            } catch {
-                callback(.failure(error))
+            } catch let error as DecodingError {
+                callback(.failure(APIotaClientError<T.ErrorResponse>.decodingError(error)))
                 return
+            } catch {
+                callback(.failure(APIotaClientError<T.ErrorResponse>.internalError(error)))
             }
         }
 

--- a/Sources/APIota/APIotaClient.swift
+++ b/Sources/APIota/APIotaClient.swift
@@ -60,7 +60,7 @@ public extension APIotaClient {
                 defer {
                     session.invalidateAndCancel()
                 }
-                callback(.failure(error!))
+                callback(.failure(APIotaClientError<T.ErrorResponse>.internalError(error!)))
 
                 return
             }

--- a/Sources/APIota/APIotaCodableEndpoint.swift
+++ b/Sources/APIota/APIotaCodableEndpoint.swift
@@ -60,8 +60,16 @@ public extension APIotaCodableEndpoint {
 
         var request = URLRequest(url: requestUrl)
         request.httpMethod = httpMethod.rawValue
-        if let httpBody = httpBody, let bodyData = try? encoder.encode(httpBody) {
-            request.httpBody = bodyData
+
+        if let httpBody = httpBody {
+            do {
+                let bodyData = try encoder.encode(httpBody)
+                request.httpBody = bodyData
+            } catch let error as EncodingError {
+                throw APIotaClientError<ErrorResponse>.encodingError(error)
+            } catch {
+                throw APIotaClientError<ErrorResponse>.internalError(error)
+            }
         }
 
         if let headers = headers {

--- a/Sources/APIota/Error/APIotaClientError.swift
+++ b/Sources/APIota/Error/APIotaClientError.swift
@@ -5,11 +5,26 @@ import Foundation
 /// The `ErrorResponse` type should match the associated type
 /// from an `APIotaCodableEndpoint` type.
 public enum APIotaClientError<ErrorResponse: Decodable>: LocalizedError {
+
     /// The `URLRequest` could not be initialized with a valid `URL`.
     case clientSide
 
-    /// The server returned a failed response indicated by a non successful `HTTPStatusCode`.
+    /// The response body could not be decoded to the specified type.
+    case decodingError(_ error: DecodingError)
+
+    /// The request body could not be encoded to the specified type.
+    case encodingError(_ error: EncodingError)
+
+    /// The server returned a failed response indicated by a non-successful `HTTPStatusCode`.
+    ///
+    /// If the `errorResponseBody` cannot be decoded to the `ErrorResponse` type,
+    /// the raw response body `Data` will be returned (or empty `Data` if there was no response body).
     case failedResponse(statusCode: HTTPStatusCode, errorResponseBody: ErrorResponse)
+
+    /// An internal error occured.
+    ///
+    /// When the circumstances that caused the error cannot be determined, an `internalError` will be thrown.
+    case internalError(_ error: Error)
 
     /// The server returned a response that was not a `HTTPURLResponse`.
     case unexpectedResponse
@@ -21,9 +36,21 @@ public enum APIotaClientError<ErrorResponse: Decodable>: LocalizedError {
             return NSLocalizedString("The URLRequest was not initialized with a valid URL.",
                                      comment: "'clientSide' API Client error text")
 
+        case .decodingError(let error):
+            return NSLocalizedString("Decoding the response body failed with error: \(error)",
+                                     comment: "'.decodingError(…)' API Client error text")
+
+        case .encodingError(let error):
+            return NSLocalizedString("Encoding the response body failed with error: \(error)",
+                                     comment: "'.encodingError(…)' API Client error text")
+
         case .failedResponse(statusCode: let code, errorResponseBody: let body):
             return NSLocalizedString("The response failed with HTTP status code: \(code) and response body: \(body)",
                                      comment: "'failedResponse' API Client error text")
+
+        case .internalError(let error):
+            return NSLocalizedString("The request failed with error: \(error)",
+                                     comment: "'internalError' API Client error text")
 
         case .unexpectedResponse:
             return NSLocalizedString("The response was of an unexpected format.",


### PR DESCRIPTION
This PR:

- Adds new error cases to `APIotaClientError`:
  - `decodingError` and `encodingError` for reporting failures relating to parsing JSON from request or response bodies.
  - `internalError` for reporting non-specific errors, where the actual context cannot be determined.