### PR TITLE
Resolve a Swift 5.2 compiler error

### DIFF
--- a/Sources/APIota/APIotaClient.swift
+++ b/Sources/APIota/APIotaClient.swift
@@ -58,7 +58,7 @@ public extension APIotaClient {
 
             guard error == nil else {
                 defer {
-                    session.invalidateAndCancel()
+                    self.session.invalidateAndCancel()
                 }
                 callback(.failure(APIotaClientError<T.ErrorResponse>.internalError(error!)))
 


### PR DESCRIPTION
- This resolves a compiler error when building with Swift 5.2.