### PR TITLE
SwiftLint 'identifier_name' rule exceptions

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -20,6 +20,10 @@ opt_in_rules:
 identifier_name:
   excluded:
   - id
+  - if
+  - im
+  - ok
+  - te
   - to
 
 warning_threshold: 1

--- a/Sources/APIota/HTTP/HTTPHeader.swift
+++ b/Sources/APIota/HTTP/HTTPHeader.swift
@@ -91,9 +91,7 @@ public struct HTTPHeader {
     public static let hobareg = HTTPHeader("Hobareg")
     public static let host = HTTPHeader("Host")
     public static let http2Settings = HTTPHeader("HTTP2-Settings")
-    // swiftlint:disable:next identifier_name
     public static let im = HTTPHeader("IM")
-    // swiftlint:disable:next identifier_name
     public static let `if` = HTTPHeader("If")
     public static let ifMatch = HTTPHeader("If-Match")
     public static let ifModifiedSince = HTTPHeader("If-Modified-Since")
@@ -172,7 +170,6 @@ public struct HTTPHeader {
     public static let surrogateCapability = HTTPHeader("Surrogate-Capability")
     public static let surrogateControl = HTTPHeader("Surrogate-Control")
     public static let tcn = HTTPHeader("TCN")
-    // swiftlint:disable:next identifier_name
     public static let te = HTTPHeader("TE")
     public static let timeout = HTTPHeader("Timeout")
     public static let topic = HTTPHeader("Topic")

--- a/Sources/APIota/HTTP/HTTPStatusCode.swift
+++ b/Sources/APIota/HTTP/HTTPStatusCode.swift
@@ -67,7 +67,6 @@ public enum HTTPStatusCode: Int {
     case processing = 102
     case earlyHints = 103
 
-    // swiftlint:disable:next identifier_name
     case ok = 200
     case created = 201
     case accepted = 202


### PR DESCRIPTION
This PR:

- Adds some exceptions for the `identifier_name` SwiftLint rule
  - Removes now-redundant `// swiftlint:disable:next identifier_name` comments