### PR TITLE
Update CI workflow for ‘master’ to ‘main’ renaming

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,9 +2,9 @@ name: "APIota CI"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
This PR:

- Allows CI pipeline to run once again by handling default branch renaming from `master` to `main`.